### PR TITLE
Add missing headers to compile on Visual Studio 2017

### DIFF
--- a/SoftwareRasterizer/QuadDecomposition.h
+++ b/SoftwareRasterizer/QuadDecomposition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <xmmintrin.h>
 
 class QuadDecomposition
 {

--- a/SoftwareRasterizer/Rasterizer.h
+++ b/SoftwareRasterizer/Rasterizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <xmmintrin.h>
+#include <immintrin.h>
 
 #include <memory>
 #include <vector>

--- a/SoftwareRasterizer/VectorMath.h
+++ b/SoftwareRasterizer/VectorMath.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <xmmintrin.h>
+#include <smmintrin.h>
 
 // Cross product
 inline __m128 cross(__m128 a, __m128 b)


### PR DESCRIPTION
I had to add these headers to compile without errors on Windows 10 and latest Visual Studio.